### PR TITLE
Navbar Update

### DIFF
--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -11,7 +11,7 @@ import { getAuthToken, requireAuth } from "../src/utils";
 import { RootState } from "../src/store/store";
 import { faCubes, faCode, faTh, faLaptopCode } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useRouter } from "next/router";
+import Link from "next/link";
 
 interface HomeProps {
   initialReduxState?: RootState;
@@ -55,7 +55,7 @@ const useStyles = makeStyles(theme => ({
   },
   cardInnerContainer: {
     padding: "25px",
-    height: "285px"
+    minHeight: "285px"
   },
   title: {
     fontWeight: "bold"
@@ -68,7 +68,6 @@ const useStyles = makeStyles(theme => ({
 
 function Home(props: HomeProps) {
   const classes = useStyles();
-  const router = useRouter();
   const appItems = [{
     icon: faCubes,
     title: "Blueprints",
@@ -90,23 +89,22 @@ function Home(props: HomeProps) {
     subtitle: "Create a JSON blob that can be fetched by your application.",
     url: "/fragments"
   }];
-  const handleClick = (url) => (event) => {
-    router.push(url);
-  };
   const renderCard = (item) => (
     <Card elevation={3} className={classes.card}>
-      <CardActionArea onClick={handleClick(item.url)}>
-        <div className={classes.cardInnerContainer}>
-          <FontAwesomeIcon icon={item.icon} size="7x" fixedWidth/>
-          <Typography variant="h6" component="div" className={classes.title}>
-            {item.title}
-          </Typography>
-          <Divider />
-          <Typography variant="subtitle1" component="div" className={classes.subtitle}>
-            {item.subtitle}
-          </Typography>
-        </div>
-      </CardActionArea>
+      <Link href={item.url}>
+        <CardActionArea component="a">
+          <div className={classes.cardInnerContainer}>
+            <FontAwesomeIcon icon={item.icon} size="7x" fixedWidth/>
+            <Typography variant="h6" component="div" className={classes.title}>
+              {item.title}
+            </Typography>
+            <Divider />
+            <Typography variant="subtitle1" component="div" className={classes.subtitle}>
+              {item.subtitle}
+            </Typography>
+          </div>
+        </CardActionArea>
+      </Link>
     </Card>
   );
   return (

--- a/src/components/Menu/Menu.props.ts
+++ b/src/components/Menu/Menu.props.ts
@@ -8,8 +8,9 @@ export interface MenuProps {
   disableRipple?: boolean;
   menuItems: {
     name: string;
-    onClick: () => void;
+    onClick?: () => void;
     startIcon?: ReactElement;
     endIcon?: ReactElement;
+    url?: string;
   }[];
 };

--- a/src/components/Menu/Menu.styles.ts
+++ b/src/components/Menu/Menu.styles.ts
@@ -13,5 +13,8 @@ export const useStyles = makeStyles((theme) => ({
   },
   itemEndIcon: {
     marginLeft: "5px"
+  },
+  popper: {
+    zIndex: theme.zIndex.appBar + 1
   }
 }));

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -76,7 +76,7 @@ const Menu = (props: MenuProps) => {
       >
         {props.menuName}
       </Button>
-      <Popper open={open} anchorEl={anchorRef.current} role={undefined} transition disablePortal placement="bottom-end">
+      <Popper open={open} anchorEl={anchorRef.current} role={undefined} transition disablePortal placement="bottom-end" className={classes.popper}>
         {({ TransitionProps, placement }) => (
           <Grow
             {...TransitionProps}

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -44,6 +44,14 @@ const Menu = (props: MenuProps) => {
     prevOpen.current = open;
   }, [open]);
   
+  useEffect(() => {
+    const handleResize = () => {
+      setOpen(false);
+    };
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
   const renderMenuItem = (menuItem, index) => {
     return menuItem.url ? (
       <Link href={menuItem.url} key={index}>
@@ -76,7 +84,7 @@ const Menu = (props: MenuProps) => {
       >
         {props.menuName}
       </Button>
-      <Popper open={open} anchorEl={anchorRef.current} role={undefined} transition disablePortal placement="bottom-end" className={classes.popper}>
+      <Popper open={open} anchorEl={anchorRef.current} role={undefined} transition placement="bottom-end" className={classes.popper}>
         {({ TransitionProps, placement }) => (
           <Grow
             {...TransitionProps}

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -8,6 +8,7 @@ import MenuItem from "@material-ui/core/MenuItem";
 import MenuList from "@material-ui/core/MenuList";
 import { useStyles } from "./Menu.styles";
 import { MenuProps } from "./Menu.props";
+import Link from "next/link";
 
 const Menu = (props: MenuProps) => {
   const classes = useStyles(props);
@@ -43,6 +44,24 @@ const Menu = (props: MenuProps) => {
     prevOpen.current = open;
   }, [open]);
   
+  const renderMenuItem = (menuItem, index) => {
+    return menuItem.url ? (
+      <Link href={menuItem.url} key={index}>
+        <MenuItem component="a" onClick={handleClose}>
+          {menuItem.startIcon ? (<span className={classes.itemStartIcon}>{menuItem.startIcon}</span>) : null}
+          {menuItem.name}
+          {menuItem.endIcon ? (<span className={classes.itemEndIcon}>{menuItem.endIcon}</span>) : null}
+        </MenuItem>
+      </Link>
+    ) : (
+      <MenuItem key={index} onClick={(e) => {handleClose(e); menuItem.onClick();}}>
+        {menuItem.startIcon ? (<span className={classes.itemStartIcon}>{menuItem.startIcon}</span>) : null}
+        {menuItem.name}
+        {menuItem.endIcon ? (<span className={classes.itemEndIcon}>{menuItem.endIcon}</span>) : null}
+      </MenuItem>
+    );
+  };
+
   return (
     <div className={classes.root} id={props.id}>
       <Button
@@ -66,13 +85,7 @@ const Menu = (props: MenuProps) => {
             <Paper>
               <ClickAwayListener onClickAway={handleClose}>
                 <MenuList autoFocusItem={open} id={props.id} onKeyDown={handleListKeyDown}>
-                  {props.menuItems.map((menuItem, index) => (
-                    <MenuItem key={index} onClick={(e) => {handleClose(e); menuItem.onClick()}}>
-                      {menuItem.startIcon ? (<span className={classes.itemStartIcon}>{menuItem.startIcon}</span>) : null}
-                      {menuItem.name}
-                      {menuItem.endIcon ? (<span className={classes.itemEndIcon}>{menuItem.endIcon}</span>) : null}
-                    </MenuItem>
-                  ))}
+                  {props.menuItems.map(renderMenuItem)}
                 </MenuList>
               </ClickAwayListener>
             </Paper>

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -84,7 +84,7 @@ const Menu = (props: MenuProps) => {
       >
         {props.menuName}
       </Button>
-      <Popper open={open} anchorEl={anchorRef.current} role={undefined} transition placement="bottom-end" className={classes.popper}>
+      <Popper open={open} anchorEl={anchorRef.current} role={undefined} disablePortal transition placement="bottom-end" className={classes.popper}>
         {({ TransitionProps, placement }) => (
           <Grow
             {...TransitionProps}

--- a/src/components/Navbar/Navbar.styles.ts
+++ b/src/components/Navbar/Navbar.styles.ts
@@ -14,12 +14,8 @@ export const useStyles = makeStyles((theme) => ({
   gridItem: {
     "& #navbar-user-menu": {
       textAlign: "right",
-      margin: "0 13px",
-      "& .MuiButton-root": {
-        [theme.breakpoints.up(theme.breakpoints.values.lg)]: {
-          fontSize: "14px"
-        },
-        [theme.breakpoints.down(theme.breakpoints.values.lg)]: {
+      [theme.breakpoints.down(theme.breakpoints.values.lg)]:{
+        "& .MuiButton-label": {
           fontSize: "12px"
         }
       }
@@ -54,13 +50,6 @@ export const useStyles = makeStyles((theme) => ({
   navItem: {
     fontWeight: "bold",
     height: "64px",
-    borderRadius: "0",
-    margin: "0 5px",
-    [theme.breakpoints.up(theme.breakpoints.values.lg)]: {
-      fontSize: "14px"
-    },
-    [theme.breakpoints.down(theme.breakpoints.values.lg)]: {
-      fontSize: "12px"
-    }
+    borderRadius: "0"
   }
 }));

--- a/src/components/Navbar/Navbar.styles.ts
+++ b/src/components/Navbar/Navbar.styles.ts
@@ -6,7 +6,10 @@ export const useStyles = makeStyles((theme) => ({
     position: "relative"
   },
   gridContainer: {
-    height: "100%"
+    height: "100%",
+    "& #navbar-brand": {
+      textAlign: "center",
+    }
   },
   gridItem: {
     "& #navbar-user-menu": {
@@ -37,10 +40,10 @@ export const useStyles = makeStyles((theme) => ({
   },
   brandText: {
     width: "100%",
-    display: "block",
+    display: "inline",
     fontWeight: "bold",
     lineHeight: "64px",
-    textAlign: "center",
+    cursor: "pointer",
     [theme.breakpoints.up(theme.breakpoints.values.lg)]: {
       fontSize: "35px"
     },

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -77,10 +77,12 @@ function Navbar(props: NavbarProps) {
   };
 
   const renderBranding = () => (
-    <Typography component="h4" variant="h4" className={classes.brandText}>
-      <FontAwesomeIcon icon={faMountain} className={classes.brandIcon} />
-      EVEREST
-    </Typography>
+    <Link href={isAuthenticated ? "/home" : "/"}>
+      <Typography component="a" variant="h4" className={classes.brandText}>
+        <FontAwesomeIcon icon={faMountain} className={classes.brandIcon} />
+        EVEREST
+      </Typography>
+    </Link>
   );
 
   const renderNavigation = () => (
@@ -114,7 +116,7 @@ function Navbar(props: NavbarProps) {
           <Grid item xs={2} sm={4} lg={4} className={classes.gridItem}>
             {isAuthenticated && renderNavigation()}
           </Grid>
-          <Grid item xs={8} sm={4} lg={4} className={classes.gridItem}>
+          <Grid id="navbar-brand" item xs={8} sm={4} lg={4} className={classes.gridItem}>
             {renderBranding()}
           </Grid>
           <Grid item xs={2} sm={4} lg={4} className={classes.gridItem}>

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,12 +1,23 @@
-import {useState, useEffect} from "react";
+import {useState, useEffect, ReactElement} from "react";
 import AppBar from "@material-ui/core/AppBar";
 import Toolbar from "@material-ui/core/Toolbar";
 import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
-import Button from "@material-ui/core/Button";
 import IconButton from "@material-ui/core/IconButton";
+import Button from "@material-ui/core/Button";
 import Hidden from "@material-ui/core/Hidden";
-import { faMountain, faBars, faKey, faSignOutAlt, faCaretDown } from "@fortawesome/free-solid-svg-icons";
+import { 
+  faMountain, 
+  faBars, 
+  faKey, 
+  faSignOutAlt, 
+  faCaretDown, 
+  faCubes, 
+  faCode, 
+  faTh, 
+  faLaptopCode,
+  faSitemap
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { connect } from "react-redux";
 import { useStyles } from "./Navbar.styles";
@@ -16,9 +27,11 @@ import Sidebar from "../Sidebar/Sidebar";
 import Menu from "../Menu/Menu";
 import { NavbarProps } from "./Navbar.props";
 import { logout } from "../../store/actions/auth";
+import { useWidth } from "../../utils";
 
 function Navbar(props: NavbarProps) {
   const classes = useStyles();
+  const breakpoint = useWidth();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const isAuthenticated = props.user || false;
 
@@ -35,46 +48,73 @@ function Navbar(props: NavbarProps) {
     return () => window.removeEventListener("resize", resizeCallback);
   }, []);
 
-  const navigationItems = [{
-    name: "Components",
-    url: "/components"
-  }, {
-    name: "Fragments",
-    url: "/fragments"
-  }, {
-    name: "Layouts",
-    url: "/layouts"
-  }];
-
   const userMenuProps = {
     id: "navbar-user-menu",
     menuName: props.user && props.user.displayName || "My Account",
     menuItems: [{
       name: "Change Password",
-      startIcon: <FontAwesomeIcon icon={faKey}/>,
+      startIcon: <FontAwesomeIcon icon={faKey} fixedWidth/>,
       onClick: () => {
         console.log("Change Password");
       }
     }, {
       name: "Sign Out",
-      startIcon: <FontAwesomeIcon icon={faSignOutAlt}/>,
+      startIcon: <FontAwesomeIcon icon={faSignOutAlt} fixedWidth/>,
       onClick: () => props.logout()
     }],
-    endIcon: <FontAwesomeIcon icon={faCaretDown} />
+    endIcon: <FontAwesomeIcon icon={faCaretDown} fixedWidth/>
   };
 
-  const sidebarProps = {
+  const navItems = [{
+      name: "Blueprints",
+      startIcon: <FontAwesomeIcon icon={faCubes} fixedWidth size="lg" />,
+      url: "/blueprints"
+    }, {
+      name: "Components",
+      startIcon: <FontAwesomeIcon icon={faCode} fixedWidth size="lg"/>,
+      url: "/components"
+    }, {
+      name: "Layouts",
+      startIcon: <FontAwesomeIcon icon={faTh} fixedWidth size="lg"/>,
+      url: "/layouts"
+    }, {
+      name: "Fragments",
+      startIcon: <FontAwesomeIcon icon={faLaptopCode} fixedWidth size="lg"/>,
+      url: "/fragments"
+    }];
+
+  const sidebarProps: {
+    isOpen: boolean;
+    onClose: (event: any) => void;
+    navigationItems: {
+      name: string;
+      startIcon?: ReactElement;
+      url?: string;
+      onClick?: () => void;
+      navigationItems?: {
+        name: string;
+        startIcon?: ReactElement;
+        url?: string;
+        onClick?: () => void;
+      }[]
+    }[];
+    closeSidebar: () => void;
+  } = {
     isOpen: sidebarOpen,
     onClose: toggleSidebar(false),
-    navigationItems: [
-      ...navigationItems,
+    navigationItems: [...navItems],
+    closeSidebar: () => setSidebarOpen(false)
+  };
+  
+  if(breakpoint === "sm" || breakpoint === "xs"){
+    sidebarProps.navigationItems = [
+      ...sidebarProps.navigationItems,
       {
         name: "My Account",
         navigationItems: [...userMenuProps.menuItems]
       }
-    ],
-    closeSidebar: () => setSidebarOpen(false)
-  };
+    ];
+  }
 
   const renderBranding = () => (
     <Link href={isAuthenticated ? "/home" : "/"}>
@@ -91,15 +131,13 @@ function Navbar(props: NavbarProps) {
         <IconButton color="inherit" onClick={toggleSidebar(!sidebarOpen)}>
           <FontAwesomeIcon icon={faBars}/>
         </IconButton>
-        <Sidebar {...sidebarProps}/>
       </Hidden>
       <Hidden implementation="css" smDown>
-        {navigationItems.map((item, index) => (
-          <Link key={index} href={item.url}>
-            <Button component="a" color="inherit" className={classes.navItem}>{item.name}</Button>
-          </Link>
-        ))}
+        <Button variant="text" color="inherit" className={classes.navItem} startIcon={<FontAwesomeIcon icon={faSitemap} fixedWidth/>} onClick={toggleSidebar(!sidebarOpen)}>
+          Navigation Menu
+        </Button>
       </Hidden>
+      <Sidebar {...sidebarProps}/>
     </>
   );
   
@@ -111,7 +149,7 @@ function Navbar(props: NavbarProps) {
   
   return (
     <AppBar position="static" color="primary">
-      <Toolbar className={classes.toolbar} disableGutters>
+      <Toolbar className={classes.toolbar}>
         <Grid container alignItems="center" justify="center" className={classes.gridContainer}>
           <Grid item xs={2} sm={4} lg={4} className={classes.gridItem}>
             {isAuthenticated && renderNavigation()}

--- a/src/components/Notification/Notification.styles.ts
+++ b/src/components/Notification/Notification.styles.ts
@@ -2,7 +2,7 @@ import makeStyles from "@material-ui/core/styles/makeStyles";
 
 export const useStyles = makeStyles((theme) => ({
   container: {
-    padding: "25px 0 0 0"
+    padding: "25px 16px 0 16px"
   },
   box: {
     position: "relative",

--- a/src/components/Sidebar/Sidebar.styles.ts
+++ b/src/components/Sidebar/Sidebar.styles.ts
@@ -21,10 +21,10 @@ export const useStyles = makeStyles((theme) => ({
       top: `64px !important`,
       height: `calc(100% - 64px)`,
     },
-    "& .MuiBackdrop-root": {
-      top: `64px`,
-      height: `calc(100% - 64px)`,
-    },
+    // "& .MuiBackdrop-root": {
+    //   top: `64px`,
+    //   height: `calc(100% - 64px)`,
+    // },
     "& .MuiListItemText-primary": {
       fontSize: "0.875rem",
       fontWeight: "bold"

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -33,7 +33,8 @@ const Sidebar = (props: SidebarProps) => {
     };
     return (
       <ListItem button className={classes.menuItem} onClick={onClick}>
-        <ListItemText primary={navItem.name.toUpperCase()} inset={inset} />
+        {navItem.startIcon ? navItem.startIcon : null}
+        <ListItemText primary={navItem.name.toUpperCase()} inset={inset || !!navItem.startIcon} />
       </ListItem>
     );
   };


### PR DESCRIPTION
The Navbar needed to have more nav items than originally designed...and that led to quite a bit of issues with responsive styling. I took a simple approach and made it so that the Sidebar is always used for navigation now.

This PR contains:
* Updated Home page to utilize the next Link instead of router.
* Updated Menu to to auto-close the popper on window resize.
* Updated Menu to support links as well as onClick.
* Updated Menu styles for zIndex.
* Updated Sidebar to support rendering icons and also removed backdrop styling.
* Updated Navbar branding to a Link that takes you to the Home page.
* Updated Navbar layout for navigation items, it is now a single button that opens the sidebar.
* Updated Notification styles, added some left/right padding.